### PR TITLE
グループ作成機能の実装

### DIFF
--- a/app/assets/stylesheets/module/group.scss
+++ b/app/assets/stylesheets/module/group.scss
@@ -39,20 +39,20 @@ li {
     border-radius: 2px;
     text-align: center;
   }
-  .label {
+  &__label {
     display: block;
     line-height: 50px;
     font-weight: bold;
     text-align: right;
   }
-  .input {
+  &__input {
     float: left;
     width: 100%;
     line-height: 30px;
     padding: 10px 15px;
     box-sizing: border-box;
   }
-  .action-btn {
+  &__action-btn {
     display: inline-block;
     padding: 12px 20px;
     color: #fff;

--- a/app/assets/stylesheets/module/group.scss
+++ b/app/assets/stylesheets/module/group.scss
@@ -39,20 +39,20 @@ li {
     border-radius: 2px;
     text-align: center;
   }
-  &__label {
+  .label {
     display: block;
     line-height: 50px;
     font-weight: bold;
     text-align: right;
   }
-  &__input {
+  .input {
     float: left;
     width: 100%;
     line-height: 30px;
     padding: 10px 15px;
     box-sizing: border-box;
   }
-  &__action-btn {
+  .action-btn {
     display: inline-block;
     padding: 12px 20px;
     color: #fff;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,11 +1,16 @@
 class GroupsController < ApplicationController
   def new
     @group = Group.new
+    @group.users << current_user
   end
 
   def create
-    Group.create(create_params)
-    redirect_to controller: :posts, action: :index
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
+    end
   end
 
   def edit
@@ -16,8 +21,8 @@ class GroupsController < ApplicationController
   end
 
   private
-  def create_params
-    params.require(:group).permit(:name)
+  def group_params
+    params.require(:group).permit(:name, { :user_ids => [] })
   end
 
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,14 +1,23 @@
 class GroupsController < ApplicationController
   def new
+    @group = Group.new
   end
 
   def create
+    Group.create(create_params)
+    redirect_to controller: :posts, action: :index
   end
 
   def edit
   end
 
+
   def update
+  end
+
+  private
+  def create_params
+    params.require(:group).permit(:name)
   end
 
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,5 @@
 class PostsController < ApplicationController
   def index
+    @groups = current_user.groups
   end
 end

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,11 +1,14 @@
 .chat-group-form
   %h1 新規チャットグループ
-  %form
+  /%form
+  = form_for(@group) do |f|
     .chat-group-form__field
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+        /%label.chat-group-form__label{for: "chat_group_name"} グループ名
+        = f.label :グループ名, class: "label"
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+        /%input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+        = f.text_field :name, placeholder: "グループ名を入力してください", class: "input"
     .chat-group-form__field
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field
@@ -17,4 +20,5 @@
     .chat-group-form__field
       .chat-group-form__field--left
       .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/
+        /%input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/
+        = f.submit "Save", class: 'action-btn'

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,24 +1,27 @@
 .chat-group-form
   %h1 新規チャットグループ
-  /%form
   = form_for(@group) do |f|
+    - if @group.errors.any?
+      .chat-group-form__errors
+        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
+        %ul
+          - @group.errors.full_messages.each do |message|
+            %li= message
     .chat-group-form__field
       .chat-group-form__field--left
-        /%label.chat-group-form__label{for: "chat_group_name"} グループ名
-        = f.label :グループ名, class: "label"
+        = f.label :グループ名, class: "chat-group-form__label"
       .chat-group-form__field--right
-        /%input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
-        = f.text_field :name, placeholder: "グループ名を入力してください", class: "input"
+        = f.text_field :name, placeholder: "グループ名を入力してください", class: "chat-group-form__input"
     .chat-group-form__field
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field
       .chat-group-form__field--left
-        %label.chat-group-form__label チャットメンバー
+        = f.label "チャットメンバー", class: "chat-group-form__label"
       .chat-group-form__field--right
         / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        = f.collection_check_boxes :user_ids, User.all, :id, :name
         / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
     .chat-group-form__field
       .chat-group-form__field--left
       .chat-group-form__field--right
-        /%input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/
-        = f.submit "Save", class: 'action-btn'
+        = f.submit "Save", class: 'chat-group-form__action-btn'

--- a/app/views/posts/_group.html.haml
+++ b/app/views/posts/_group.html.haml
@@ -1,0 +1,5 @@
+= link_to "#" do
+  .group
+    %p.group__group-name
+      = group.name
+    %p.group__latest-message まだメッセージはありません。

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -12,14 +12,8 @@
             = link_to edit_user_path(current_user) do
               %i.fa.fa-cog
     .groups
-      = link_to "#" do
-        .group
-          %p.group__group-name hahaha
-          %p.group__latest-message さようなら
-      = link_to "#" do
-        .group
-          %p.group__group-name hello
-          %p.group__latest-message まだメッセージがありません
+      - @groups.each do |group|
+        = render partial: "group", locals: { group: group } 
   .chat-main
     .main-header
       .main-header__left-box


### PR DESCRIPTION
# WHAT
グループ作成機能を実装し、
サイドバーにユーザーの所属しているグループの名前を表示させるようにした。

# WHY
グループ編集機能を実装する前にグループ作成の構想を固定するため。