### PR TITLE
メッセージ送信の非同期化

### DIFF
--- a/app/assets/javascripts/test.js
+++ b/app/assets/javascripts/test.js
@@ -1,0 +1,52 @@
+$(function(){
+
+  function buildMessage(message){
+
+    if (message.image_url) {
+      image_data = `<img class="lower-message__image" src=${message.image_url} alt="19248 en 1" />`
+    }
+    else {
+      image_data = ``
+    }
+
+    var html = `<div class='message'>
+                  <div class='message__upper-info'>
+                    <p class='message__upper-info__talker'>
+                      ${message.user_name}
+                    </p>
+                    <p class='message__upper-info__date'>
+                      ${message.created_at}
+                    </p>
+                  </div>
+                  <p class='message__text'>
+                    ${message.body}
+                    ${image_data}
+                  </p>
+                </div>`
+    return html;
+  }
+
+  $('#new_message').on('submit',function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(message){
+      console.log("OK")
+      var html = buildMessage(message);
+      $(".messages").append(html)
+      $('#input-box__text').val('')
+      debugger
+    })
+    .fail(function(){
+      console.log("NG")
+    })
+  })
+});

--- a/app/assets/javascripts/test.js
+++ b/app/assets/javascripts/test.js
@@ -9,7 +9,7 @@ $(function(){
       image_data = ``
     }
 
-    var html = `<div class='message'>
+    var html = `<div class='message last'>
                   <div class='message__upper-info'>
                     <p class='message__upper-info__talker'>
                       ${message.user_name}
@@ -39,14 +39,19 @@ $(function(){
       contentType: false
     })
     .done(function(message){
-      console.log("OK")
       var html = buildMessage(message);
       $(".messages").append(html)
-      $('#input-box__text').val('')
-      debugger
+      $('.input-box__text').val('')
+      $('.input-box__image__file').val('')
+      $(".messages").animate({scrollTop:$(".messages")[0].scrollHeight},200)
+      $(".submit-btn").prop("disabled", false);
+
     })
     .fail(function(){
-      console.log("NG")
+      alert('メッセージを入力して下さい');
+      $(".submit-btn").prop("disabled", false);
     })
   })
 });
+
+

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html{redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'}
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -3,7 +3,7 @@
     %p.message__upper-info__talker
       = message.user.name
     %p.message__upper-info__date
-      = message.created_at
+      = message.created_at.strftime("%Y-%m-%d %H:%M:%S")
   %p.message__text
     = message.body
     = image_tag message.image.url,class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at
+json.body @message.body
+json.image_url @message.image.url

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,4 @@
 json.user_name @message.user.name
-json.created_at @message.created_at
+json.created_at @message.created_at.strftime("%Y-%m-%d %H:%M:%S")
 json.body @message.body
 json.image_url @message.image.url

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
 
   factory :user do
-    password = Faker::Internet.password(min_length: 8)
+   # password = Faker::Internet.password(min_length: 8)
     name {Faker::Name.last_name}
     email {Faker::Internet.free_email}
     password {password}


### PR DESCRIPTION
# WHAT 
下記のようにメッセージ送信機能の仕様を変更した
・メッセージ送信後にリロードしないで投稿後の画面に遷移する
・投稿と同時に最下部までスクロールする
・投稿後も連続でメッセージ送信が可能
・メッセージが送信できなかった場合はエラーを知らせるようなアラートを出す
# WHY
メッセージ送信毎に読み込みが行われなくすることで
サーバとの通信負荷を軽減する。
